### PR TITLE
Fixes cut and drilldown menus for hierarchies hasAll=false

### DIFF
--- a/src/components/CutMenu.js
+++ b/src/components/CutMenu.js
@@ -19,7 +19,7 @@ export default function CutMenu(props, context) {
                 <ul className="dropdown-menu">
                     {d.hierarchies[0]
                     .levels
-                    .slice(1)
+                    .slice(d.hierarchies[0].allMemberName ? 1 : 0)
                       .map((l,j) =>
                           <li key={`${i}.${j}`}
                               onClick={() => dispatch(showCutModal(l))}>

--- a/src/components/DrillDownMenu.js
+++ b/src/components/DrillDownMenu.js
@@ -17,7 +17,7 @@ export default function DrillDownMenu(props, context) {
           <ul className="dropdown-menu">
             {d.hierarchies[0]
               .levels
-              .slice(1)
+              .slice(d.hierarchies[0].allMemberName ? 1 : 0)
               .map((l,j) =>
                 <li key={`${i}.${j}`}
                     onClick={() => dispatch(addDrilldown(l))}>


### PR DESCRIPTION
There may be some instances where we want to set hasAll to false and this could let users still drilldown & cut on those hierarchies (otherwise right now you see empty lists).